### PR TITLE
Fix format_line example

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ A header-only C write client for InfluxDB.
   int used = 0;
 
   for (int i = 0; i < 10; ++i) {
-      used = format_line(line, &len, used,
+      used = format_line(&line, &len, used,
           INFLUX_MEAS("foo"),
           INFLUX_TAG("k", "v"),
           INFLUX_F_INT("x", i),


### PR DESCRIPTION
The example of `format_line` does not work.  `format_line` needs to have the address of the string passed to it.  So I have added a `&` to do that.